### PR TITLE
fix: remove residual coin dust after selling all coins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.17.28'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.session:spring-session-core'
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:7.10.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
 						.successHandler(successHandler())
 						.authorizationEndpoint(authorization -> authorization
 								.authorizationRequestResolver(customAuthorizationRequestResolver()))
-						.defaultSuccessUrl("http://localhost:5173", true));
+						.defaultSuccessUrl("https://dev.playkono.com", true));
 		return http.build();
 	}
 

--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -57,7 +57,7 @@ public class SecurityConfig {
 						.successHandler(successHandler())
 						.authorizationEndpoint(authorization -> authorization
 								.authorizationRequestResolver(customAuthorizationRequestResolver()))
-						.defaultSuccessUrl("https://dev.playkono.com", true));
+						.defaultSuccessUrl("http://localhost:5173", true));
 		return http.build();
 	}
 

--- a/src/main/java/org/secretjuju/kono/service/CoinService.java
+++ b/src/main/java/org/secretjuju/kono/service/CoinService.java
@@ -86,10 +86,10 @@ public class CoinService {
 		if (coinSellBuyRequestDto.getOrderAmount() == null) {
 			// orderQuantity가 설정되어 있으면 그것을 기준으로 orderAmount 계산
 			if (coinSellBuyRequestDto.getOrderQuantity() != null && coinSellBuyRequestDto.getOrderQuantity() > 0) {
-				Long calculatedAmount = Math.round(coinSellBuyRequestDto.getOrderQuantity() * currentPrice) + 2; // 소수점
-																													// 가격
-																													// 남는것
-																													// 방지
+				Long calculatedAmount = Math.round(coinSellBuyRequestDto.getOrderQuantity() * currentPrice); // 소수점
+																												// 가격
+																												// 남는것
+																												// 방지
 				coinSellBuyRequestDto.setOrderAmount(calculatedAmount);
 			} else {
 				throw new CustomException(400, "거래시 주문금액 혹은 갯수 필수값이 누락되었습니다.");
@@ -243,7 +243,7 @@ public class CoinService {
 			holding.setHoldingQuantity(holding.getHoldingQuantity() - request.getOrderQuantity());
 
 			// 코인을 모두 판매한 경우 보유 목록에서 제거(0.1오류 로직 부분 검토 코드)
-			if (holding.getHoldingQuantity() <= 0) {
+			if (holding.getHoldingQuantity() <= 0.00001 || holding.getHoldingPrice() <= 1) {
 				user.getCoinHoldings().remove(holding);
 			}
 			// 현금 잔액 증가


### PR DESCRIPTION
## 📌 Description
많은 기능 수정 했습니다.
- 코인 전체 판매시 잔여코인이 남는 현상을 수정했습니다.
- 코인 분할 판매시 투자금이 남는 현상을 수정했습니다.
- 코인 판매시 수수료를 적용했습니다. (잔여코인이 생기면 삭제 됨 0.00000001개 미만 )

## 🔗 Related Issues
- Resolves 
- #70 
- #64
-  #66 

## ✨ Changes Made

1. 🛠️ [orderAmount가 null일 때 수량으로 계산]
2. 📝 [다시 수량 계산]



## ✅ Checklist

- [x] 🔄 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] ✅ 모든 테스트가 성공적으로 통과했습니다.
- [ ] 📚 관련 문서를 업데이트했습니다.
- [ ] 🔗 PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 🎨 코드 스타일 가이드라인을 준수했습니다.
- [ ] 👀 코드 리뷰어를 지정했습니다.
