### PR TITLE
fix: 회원탈퇴 cascade,nickname 인가

### DIFF
--- a/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
+++ b/src/main/java/org/secretjuju/kono/config/SecurityConfig.java
@@ -87,12 +87,14 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration
-				.setAllowedOrigins(Arrays.asList(frontendRedirectUri, "http://localhost:4173", cloudFrontRedirectUri)); // 프론트엔드
-																														// 주소
+		configuration.setAllowedOrigins(Arrays.asList(frontendRedirectUri, "http://localhost:5173",
+				"https://www.playcono.com", "https://playcono.com", cloudFrontRedirectUri));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-		configuration.setAllowedHeaders(Arrays.asList("*"));
+		configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "Accept",
+				"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"));
+		configuration.setExposedHeaders(Arrays.asList("Set-Cookie", "Authorization"));
 		configuration.setAllowCredentials(true);
+		configuration.setMaxAge(3600L);
 
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 		source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/org/secretjuju/kono/service/UserService.java
+++ b/src/main/java/org/secretjuju/kono/service/UserService.java
@@ -101,16 +101,20 @@ public class UserService {
 	@Transactional
 	public void withdrawUser(Long kakaoId) {
 		try {
+			// 1. 카카오 연결 해제
 			String adminKeyHeader = "KakaoAK " + adminKey;
-
 			webClient.post().uri("/v1/user/unlink").header("Authorization", adminKeyHeader)
 					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 					.body(BodyInserters.fromFormData("target_id_type", "user_id").with("target_id", kakaoId.toString()))
 					.retrieve().bodyToMono(String.class).block();
-
 			log.info("카카오 연결끊기 성공: kakaoId={}", kakaoId);
-			userRepository.deleteByKakaoId(kakaoId);
 
+			// 2. 사용자 조회
+			User user = userRepository.findByKakaoId(kakaoId)
+					.orElseThrow(() -> new UserNotFoundException("User not found with kakaoId: " + kakaoId));
+
+			// 3. 사용자 삭제 (cascade 설정으로 관련 엔티티도 함께 삭제)
+			userRepository.delete(user);
 			log.info("DB 사용자 정보 삭제 성공: kakaoId={}", kakaoId);
 
 		} catch (WebClientResponseException e) {


### PR DESCRIPTION
## 📌 Description
회원탈퇴 cascade,nickname 인가

## ✨ Changes Made
회원탈퇴시  유저의 cacase 연관부분 같이 삭제 되도록 설정, nickname api 인가부분 추가 

## 🧪 Testing
1. ✅ 닉네임 수정테스트 성공
2. 🖥️ 회원탈퇴 시 데이터베이스 연관 부분 삭제 성공(2회 연속 시도)

## ✅ Checklist
<!-- PR 작성 시 다음 항목들을 확인하세요. -->

- [ ] 🔄 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] ✅ 모든 테스트가 성공적으로 통과했습니다.
- [ ] 📚 관련 문서를 업데이트했습니다.
- [ ] 🔗 PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 🎨 코드 스타일 가이드라인을 준수했습니다.
- [ ] 👀 코드 리뷰어를 지정했습니다.

## 💡 Additional Notes
<!-- 리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요. -->
